### PR TITLE
Turbo tasks

### DIFF
--- a/app/controllers/concerns/tasks_support.rb
+++ b/app/controllers/concerns/tasks_support.rb
@@ -1,0 +1,26 @@
+module TasksSupport
+  extend ActiveSupport::Concern
+
+  private
+
+  def tasks_by_tab_status
+    case params[:tab_status]
+    when 'overdue'
+      current_user.tasks.where('due_date < ?', Date.today).where.not(status: 'completed')
+    when 'completed'
+      current_user.tasks.where(status: 'completed')
+    when "show"
+      @tab_status.nil? ? [@task] : current_user.tasks.all
+    else
+      current_user.tasks.all
+    end
+  end
+
+  def set_tab_status
+    if ['all', 'completed', 'overdue'].any? { |s| s == params[:tab_status] }
+      params[:tab_status]
+    else
+      "all"
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,11 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable
   has_many :tasks, dependent: :destroy
   validates :email, 'valid_email_2/email': {mx: true, disposable: true, disallow_subaddressing: true, dns_timeout: 30}
+
+  # Override the existing method so emails are delivered asynchronously and do not create a IO bound request.
+  def send_devise_notification(notification, *args)
+    message = devise_mailer.send(notification, self, *args)
+    
+    message.deliver_later
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="mb-2">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="mb-2">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-5">
     <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: {turbo: false}) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="mb-3">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: {turbo: false}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="mb-3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}) do |f| %>
   <div class="mb-3">
     <%= f.label :email, class: "form-label" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: task) do |form| %>
+<%= form_with(model: task, data: {turbo: false}) do |form| %>
   <% if task.errors.any? %>
     <div class="card mb-4">
       <div class="card-header text-bg-danger">

--- a/app/views/tasks/_nav_pills.html.erb
+++ b/app/views/tasks/_nav_pills.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag "nav-pills" do %>
+  <nav class="nav nav-pills nav-fill" id="nav-pills">
+    <%= link_to "All", tasks_path(tab_status: 'all'), class: "nav-link #{params[:tab_status].nil? || params[:tab_status] == 'all' || @tab_status == "all" ? 'active' : ''} text-center", data: { turbo_stream: true } %>
+    <%= link_to "Overdue", tasks_path(tab_status: 'overdue'), class: "nav-link #{params[:tab_status] == 'overdue' ? 'active' : ''} text-center", data: { turbo_stream: true } %>
+    <%= link_to "Completed", tasks_path(tab_status: 'completed'), class: "nav-link #{params[:tab_status] == 'completed' ? 'active' : ''} text-center", data: { turbo_stream: true } %>
+  </nav>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,17 +1,20 @@
-
+<% tab_status = "show" if tab_status.nil? %>
 <div class="card mb-2" id="<%= dom_id task %>">
   <div class="card-header text-bg-<%= status_color(task.status) %> d-flex justify-content-between align-items-center">
     <span>Status: <%= task.status.humanize %></span>
     <span class="d-flex gap-2">
-        <%= link_to "Edit", edit_task_path(task), class: "btn btn btn-outline-light" %>
+        <%= link_to "Edit", edit_task_path(task), class: "btn btn btn-outline-light", data: { turbo: false } %>
         <%= button_to "Destroy", task,
             form: { 
               data: { 
-                turbo_confirm: "Are you sure?"
+                turbo: tab_status == "show" ? false : true,
+                turbo_confirm: tab_status == "show" ? nil : "Are you sure?"
               }
             },
             method: :delete, 
-            class: "btn btn-dark" %>
+            class: "btn btn-dark",
+            onclick: tab_status == "show" ? "return confirm('Are you sure that you want to destroy this Task?');" : nil
+          %>
     </span>
   </div>
   <div class="card-body">
@@ -19,38 +22,43 @@
     <p class="card-text">Due: <%= format_due_date(task.due_date) %></p>
     <div class="d-flex">
       <% if task.status == "completed" %>
-        <%= button_to "Mark as Pending", 
+        <%= button_to "Mark as Pending",
                   task_path(task),
                   method: :patch,
                   data: {turbo_method: :patch},
-                  params: { task: { status: 'pending' } },
+                  params: { task: { status: 'pending' }, tab_status: tab_status },
                   class: "btn btn-outline-danger mb-2 me-2" %>
         <%= button_to "Mark as In Progress", 
-                  task_path(task), 
-                  method: :patch, 
-                  params: { task: { status: 'in_progress' } },
+                  task_path(task),
+                  method: :patch,
+                  data: {turbo_method: :patch},
+                  params: { task: { status: 'in_progress' }, tab_status: tab_status },
                   class: "btn btn-outline-warning mb-2 me-2" %>
       <% elsif task.status == "pending" %>
         <%= button_to "Mark as Completed", 
                   task_path(task),
-                  method: :patch, 
-                  params: { task: { status: 'completed' } },
+                  method: :patch,
+                  data: {turbo_method: :patch},
+                  params: { task: { status: 'completed' }, tab_status: tab_status },
                   class: "btn btn-outline-success mb-2 me-2" %>
         <%= button_to "Mark as In Progress", 
                   task_path(task), 
-                  method: :patch, 
-                  params: { task: { status: 'in_progress' } },
+                  method: :patch,
+                  data: {turbo_method: :patch},
+                  params: { task: { status: 'in_progress' }, tab_status: tab_status },
                   class: "btn btn-outline-success mb-2 me-2" %>
       <% else %>
         <%= button_to "Mark as Pending", 
                   task_path(task),
-                  method: :patch, 
-                  params: { task: { status: 'pending' } },
+                  method: :patch,
+                  data: {turbo_method: :patch},
+                  params: { task: { status: 'pending' }, tab_status: tab_status },
                   class: "btn btn-outline-warning mb-2 me-2" %>
         <%= button_to "Mark as Completed", 
                   task_path(task), 
-                  method: :patch, 
-                  params: { task: { status: 'completed' } },
+                  method: :patch,
+                  data: {turbo_method: :patch},
+                  params: { task: { status: 'completed' }, tab_status: tab_status },
                   class: "btn btn-outline-success mb-2 me-2" %>
       <% end %>
     </div>

--- a/app/views/tasks/_tasks_container.html.erb
+++ b/app/views/tasks/_tasks_container.html.erb
@@ -1,0 +1,40 @@
+<%= turbo_frame_tag "tasks-container" do %>
+  <% if tasks.present? %>
+    <% if tab_status == "all"%>
+      <div class="row status-containers">
+        <% ['pending', 'in_progress', 'completed'].each do |status| %>
+          <div class="col-md-4 status-column status-column-separator">
+            <h3 class="text-center"><%= status.titleize %></h3>
+            <div class="task-container" id="<%= status %>-tasks">
+            <hr class="my-2">
+              <% tasks.select { |task| task.status == status }.each do |task| %>
+                <%= render task, tab_status: tab_status %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% elsif tab_status == "overdue" %>
+      <div class="row status-containers">
+        <% ['pending', 'in_progress'].each do |status| %>
+          <div class="col-md-6 status-column <%= 'status-column-separator' unless status == 'completed' %>">
+            <h3 class="text-center"><%= status.titleize %></h3>
+            <div class="task-container" id="<%= status %>-tasks">
+              <% tasks.select { |task| task.status == status }.each do |task| %>
+                <%= render task, tab_status: tab_status %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="task-container">
+        <% tasks.each do |task| %>
+          <%= render task, tab_status: tab_status %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <p>No tasks found.</p>
+  <% end %>
+<% end %>

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "task_#{@task.id}" %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,49 +1,15 @@
-<div class="container">
-  <div class="d-flex justify-content-between align-items-center">
+<div class="container mt-4" data-turbo-prefetch="false">
+  <div class="d-flex justify-content-between align-items-center mb-2">
     <h1>Tasks</h1>
     <%= link_to "New task", new_task_path, class: "btn btn-primary" %>
   </div>
 
-  <nav class="nav nav-pills nav-fill mb-4">
-    <%= link_to "All", tasks_path, class: "nav-link #{params[:status].nil? ? 'active' : ''}" %>
-    <%= link_to "Overdue", tasks_path(status: 'overdue'), class: "nav-link #{params[:status] == 'overdue' ? 'active' : ''}" %>
-    <%= link_to "Completed", tasks_path(status: 'completed'), class: "nav-link #{params[:status] == 'completed' ? 'active' : ''}" %>
-  </nav>
-
-  <!-- Add a horizontal line here -->
   <hr class="my-4">
 
-  <% if params[:status].nil? %>
-    <div class="row status-containers">
-      <% ['pending', 'in_progress', 'completed'].each do |status| %>
-        <div class="col-md-4 status-column <%= 'status-column-separator' unless status == 'completed' %>">
-          <h3 class="text-center"><%= status.titleize %></h3>
-          <div class="task-container" id="<%= status %>-tasks">
-            <% @tasks.select { |task| task.status == status }.each do |task| %>
-              <%= render task %>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  <% elsif params[:status] == "overdue" %>
-    <div class="row status-containers">
-      <% ['pending', 'in_progress'].each do |status| %>
-        <div class="col-md-6 status-column <%= 'status-column-separator' unless status == 'completed' %>">
-          <h3 class="text-center"><%= status.titleize %></h3>
-          <div class="task-container" id="<%= status %>-tasks">
-            <% @tasks.select { |task| task.status == status }.each do |task| %>
-              <%= render task %>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="task-container">
-      <% @tasks.each do |task| %>
-        <%= render task %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render 'nav_pills', tasks: @tasks, tab_status: @tab_status %>
+
+  <!-- Add a horizontal line here -->
+  <hr class="mb-2">
+
+  <%= render 'tasks_container', tasks: @tasks, tab_status: @tab_status %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,11 +1,7 @@
-<%= render @task %>
-
+<%= turbo_frame_tag "tasks-container" do %>
+  <%= render @task %>
+<% end %>
 <div>
   <%= link_to "Edit this task", edit_task_path(@task) , class: "btn btn-outline-primary" %> |
-  <%= link_to "Back to tasks", tasks_path, class: "btn btn-outline-secondary"  %>
-
-  <%= button_to "Destroy this task", @task,
-              form: { data: { turbo_confirm: "Are you sure?"}},
-              method: :delete, 
-              class: "btn btn-danger mt-2" %>
+  <%= link_to "Back to tasks", tasks_path, class: "btn btn-outline-secondary", data: { turbo: false} %>
 </div>


### PR DESCRIPTION
Added Usage of TurboStream for Task:
1. Added a new param to track the tab status at index page for Tasks
2. Added TurboStream usage for index page, so that only the tasks-container is updated instead of the whole page, which then also extends to Show action.
3. Added TurboStream at destroy action.
4. Added a new concern called TasksSupport for keeping new reusable Tasks controller methods.
5. Added a new method in user model, to override the Devise mailer to use ActiveJob for sending mails as a background job. This makes the User Sign Up request to finish fast as then its not being IO bounded by the mailer.
6. Disabled Turbo For Devise forms.